### PR TITLE
Add function + tests to convert decimals with token

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": "hardhat/register",
+  "timeout": 40000,
+  "_": ["test/**/*.test.js"]
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,0 @@
-{
-  "require": "hardhat/register",
-  "timeout": 40000,
-  "_": ["test/**/*.test.js"]
-}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 # Solidity Library by Distributed Lab
 
-
 **Solidity Library for savvies by DL**
 
 The library consists of modules and utilities that are built with a help of [Openzeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) (4.9.2) and go far beyond mediocre solidity.
@@ -38,7 +37,7 @@ Once the [npm package](https://www.npmjs.com/package/@solarity/solidity-lib) is 
 ```solidity
 pragma solidity ^0.8.4;
 
-import "@solarity/solidity-lib/contracts-registry/presets/OwnableContractsRegistry.sol";
+import {OwnableContractsRegistry} from "@solarity/solidity-lib/contracts-registry/presets/OwnableContractsRegistry.sol";
 
 contract ContractsRegistry is OwnableContractsRegistry {
     . . .

--- a/contracts/libs/decimals/DecimalsConverter.sol
+++ b/contracts/libs/decimals/DecimalsConverter.sol
@@ -46,6 +46,16 @@ library DecimalsConverter {
     /**
      * @notice The function to bring the number to 18 decimals of precision
      * @param amount_ the number to convert
+     * @param token_ the token, whose decimals will be precised to 18
+     * @return the number brought to 18 decimals of precision
+     */
+    function to18(uint256 amount_, address token_) internal view returns (uint256) {
+        return to18(amount_, decimals(token_));
+    }
+
+    /**
+     * @notice The function to bring the number to 18 decimals of precision
+     * @param amount_ the number to convert
      * @param baseDecimals_ the current precision of the number
      * @return the number brought to 18 decimals of precision
      */
@@ -56,11 +66,31 @@ library DecimalsConverter {
     /**
      * @notice The function to bring the number to 18 decimals of precision. Reverts if output is zero
      * @param amount_ the number to convert
+     * @param token_ the token, whose decimals will be precised to 18
+     * @return the number brought to 18 decimals of precision
+     */
+    function to18Safe(uint256 amount_, address token_) internal view returns (uint256) {
+        return to18Safe(amount_, decimals(token_));
+    }
+
+    /**
+     * @notice The function to bring the number to 18 decimals of precision. Reverts if output is zero
+     * @param amount_ the number to convert
      * @param baseDecimals_ the current precision of the number
      * @return the number brought to 18 decimals of precision
      */
     function to18Safe(uint256 amount_, uint256 baseDecimals_) internal pure returns (uint256) {
-        return convertSafe(amount_, baseDecimals_, to18);
+        return convertSafe(amount_, baseDecimals_, precisionTo18);
+    }
+
+    /**
+     * @notice The function to bring the number from 18 decimals to the desired decimals of precision
+     * @param amount_ the number to covert
+     * @param token_ the token, whose decimals will be used as desired decimals of precision
+     * @return the number brought from 18 to desired decimals of precision
+     */
+    function from18(uint256 amount_, address token_) internal view returns (uint256) {
+        return from18(amount_, decimals(token_));
     }
 
     /**
@@ -77,11 +107,22 @@ library DecimalsConverter {
      * @notice The function to bring the number from 18 decimals to the desired decimals of precision.
      * Reverts if output is zero
      * @param amount_ the number to covert
+     * @param token_ the token, whose decimals will be used as desired decimals of precision
+     * @return the number brought from 18 to desired decimals of precision
+     */
+    function from18Safe(uint256 amount_, address token_) internal view returns (uint256) {
+        return from18Safe(amount_, decimals(token_));
+    }
+
+    /**
+     * @notice The function to bring the number from 18 decimals to the desired decimals of precision.
+     * Reverts if output is zero
+     * @param amount_ the number to covert
      * @param destDecimals_ the desired precision decimals
      * @return the number brought from 18 to desired decimals of precision
      */
     function from18Safe(uint256 amount_, uint256 destDecimals_) internal pure returns (uint256) {
-        return convertSafe(amount_, destDecimals_, from18);
+        return convertSafe(amount_, destDecimals_, precisionFrom18);
     }
 
     /**
@@ -116,12 +157,7 @@ library DecimalsConverter {
         address baseToken_,
         address destToken_
     ) internal view returns (uint256) {
-        return
-            convert(
-                amount_,
-                uint256(IERC20Metadata(baseToken_).decimals()),
-                uint256(IERC20Metadata(destToken_).decimals())
-            );
+        return convert(amount_, uint256(decimals(baseToken_)), uint256(decimals(destToken_)));
     }
 
     /**
@@ -139,6 +175,17 @@ library DecimalsConverter {
         return convertTokensSafe(amount_, baseToken_, destToken_, roundTokens);
     }
 
+    function precisionTo18(uint256 amount_, uint256 baseDecimals_) private pure returns (uint256) {
+        return convert(amount_, baseDecimals_, 18);
+    }
+
+    function precisionFrom18(
+        uint256 amount_,
+        uint256 destDecimals_
+    ) private pure returns (uint256) {
+        return convert(amount_, 18, destDecimals_);
+    }
+
     /**
      * @notice The function to do the precision convertion
      * @param amount_ the amount to covert
@@ -150,7 +197,7 @@ library DecimalsConverter {
         uint256 amount_,
         uint256 baseDecimals_,
         uint256 destDecimals_
-    ) internal pure returns (uint256) {
+    ) private pure returns (uint256) {
         if (baseDecimals_ > destDecimals_) {
             amount_ = amount_ / 10 ** (baseDecimals_ - destDecimals_);
         } else if (baseDecimals_ < destDecimals_) {
@@ -171,7 +218,7 @@ library DecimalsConverter {
         uint256 amount_,
         uint256 decimals_,
         function(uint256, uint256) internal pure returns (uint256) _convertFunc
-    ) internal pure returns (uint256 conversionResult_) {
+    ) private pure returns (uint256 conversionResult_) {
         conversionResult_ = _convertFunc(amount_, decimals_);
 
         require(conversionResult_ > 0, "DecimalsConverter: conversion failed");
@@ -190,7 +237,7 @@ library DecimalsConverter {
         address baseToken_,
         address destToken_,
         function(uint256, address, address) internal view returns (uint256) _convertFunc
-    ) internal view returns (uint256 conversionResult_) {
+    ) private view returns (uint256 conversionResult_) {
         conversionResult_ = _convertFunc(amount_, baseToken_, destToken_);
 
         require(conversionResult_ > 0, "DecimalsConverter: conversion failed");

--- a/contracts/libs/decimals/DecimalsConverter.sol
+++ b/contracts/libs/decimals/DecimalsConverter.sol
@@ -80,7 +80,7 @@ library DecimalsConverter {
      * @return the number brought to 18 decimals of precision
      */
     function to18Safe(uint256 amount_, uint256 baseDecimals_) internal pure returns (uint256) {
-        return convertSafe(amount_, baseDecimals_, precisionTo18);
+        return _convertSafe(amount_, baseDecimals_, _to18);
     }
 
     /**
@@ -122,7 +122,7 @@ library DecimalsConverter {
      * @return the number brought from 18 to desired decimals of precision
      */
     function from18Safe(uint256 amount_, uint256 destDecimals_) internal pure returns (uint256) {
-        return convertSafe(amount_, destDecimals_, precisionFrom18);
+        return _convertSafe(amount_, destDecimals_, _from18);
     }
 
     /**
@@ -142,7 +142,7 @@ library DecimalsConverter {
      * @return the rounded number. Comes with 18 precision decimals
      */
     function round18Safe(uint256 amount_, uint256 decimals_) internal pure returns (uint256) {
-        return convertSafe(amount_, decimals_, round18);
+        return _convertSafe(amount_, decimals_, round18);
     }
 
     /**
@@ -152,38 +152,12 @@ library DecimalsConverter {
      * @param destToken_ desired token
      * @return the converted number
      */
-    function roundTokens(
+    function convert(
         uint256 amount_,
         address baseToken_,
         address destToken_
     ) internal view returns (uint256) {
         return convert(amount_, uint256(decimals(baseToken_)), uint256(decimals(destToken_)));
-    }
-
-    /**
-     * @notice The function to do the token precision convertion. Reverts if output is zero
-     * @param amount_ the amount to convert
-     * @param baseToken_ current token
-     * @param destToken_ desired token
-     * @return the converted number
-     */
-    function roundTokensSave(
-        uint256 amount_,
-        address baseToken_,
-        address destToken_
-    ) internal view returns (uint256) {
-        return convertTokensSafe(amount_, baseToken_, destToken_, roundTokens);
-    }
-
-    function precisionTo18(uint256 amount_, uint256 baseDecimals_) private pure returns (uint256) {
-        return convert(amount_, baseDecimals_, 18);
-    }
-
-    function precisionFrom18(
-        uint256 amount_,
-        uint256 destDecimals_
-    ) private pure returns (uint256) {
-        return convert(amount_, 18, destDecimals_);
     }
 
     /**
@@ -197,7 +171,7 @@ library DecimalsConverter {
         uint256 amount_,
         uint256 baseDecimals_,
         uint256 destDecimals_
-    ) private pure returns (uint256) {
+    ) internal pure returns (uint256) {
         if (baseDecimals_ > destDecimals_) {
             amount_ = amount_ / 10 ** (baseDecimals_ - destDecimals_);
         } else if (baseDecimals_ < destDecimals_) {
@@ -208,13 +182,63 @@ library DecimalsConverter {
     }
 
     /**
+     * @notice The function to do the token precision convertion. Reverts if output is zero
+     * @param amount_ the amount to convert
+     * @param baseToken_ current token
+     * @param destToken_ desired token
+     * @return the converted number
+     */
+    function convertTokensSafe(
+        uint256 amount_,
+        address baseToken_,
+        address destToken_
+    ) internal view returns (uint256) {
+        return _convertTokensSafe(amount_, baseToken_, destToken_, _convertTokens);
+    }
+
+    /**
+     * @notice The function to bring the number to 18 decimals of precision
+     * @param amount_ the number to convert
+     * @param baseDecimals_ the current precision of the number
+     * @return the number brought to 18 decimals of precision
+     */
+    function _to18(uint256 amount_, uint256 baseDecimals_) private pure returns (uint256) {
+        return convert(amount_, baseDecimals_, 18);
+    }
+
+    /**
+     * @notice The function to bring the number from 18 decimals to the desired decimals of precision
+     * @param amount_ the number to covert
+     * @param destDecimals_ the desired precision decimals
+     * @return the number brought from 18 to desired decimals of precision
+     */
+    function _from18(uint256 amount_, uint256 destDecimals_) private pure returns (uint256) {
+        return convert(amount_, 18, destDecimals_);
+    }
+
+    /**
+     * @notice The function to do the token precision convertion
+     * @param amount_ the amount to convert
+     * @param baseToken_ current token
+     * @param destToken_ desired token
+     * @return the converted number
+     */
+    function _convertTokens(
+        uint256 amount_,
+        address baseToken_,
+        address destToken_
+    ) private view returns (uint256) {
+        return convert(amount_, uint256(decimals(baseToken_)), uint256(decimals(destToken_)));
+    }
+
+    /**
      * @notice The function wrapper to do the safe precision convertion. Reverts if output is zero
      * @param amount_ the amount to covert
      * @param decimals_ the precision decimals
      * @param _convertFunc the internal function pointer to "from", "to", or "round" functions
      * @return conversionResult_ the convertion result
      */
-    function convertSafe(
+    function _convertSafe(
         uint256 amount_,
         uint256 decimals_,
         function(uint256, uint256) internal pure returns (uint256) _convertFunc
@@ -232,7 +256,7 @@ library DecimalsConverter {
      * @param _convertFunc the internal function pointer to "from", "to", or "round" functions
      * @return conversionResult_ the convertion result
      */
-    function convertTokensSafe(
+    function _convertTokensSafe(
         uint256 amount_,
         address baseToken_,
         address destToken_,

--- a/contracts/mock/libs/decimals/DecimalsConverterMock.sol
+++ b/contracts/mock/libs/decimals/DecimalsConverterMock.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import {DecimalsConverter} from "../../../libs/decimals/DecimalsConverter.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract DecimalsConverterMock {
     using DecimalsConverter for *;
@@ -32,6 +33,22 @@ contract DecimalsConverterMock {
 
     function round18Safe(uint256 amount_, uint256 decimals_) external pure returns (uint256) {
         return amount_.round18Safe(decimals_);
+    }
+
+    function roundTokens(
+        uint256 amount_,
+        address baseToken_,
+        address destToken_
+    ) public view returns (uint256) {
+        return amount_.roundTokens(baseToken_, destToken_);
+    }
+
+    function roundTokensSave(
+        uint256 amount_,
+        address baseToken_,
+        address destToken_
+    ) external view returns (uint256) {
+        return amount_.roundTokensSave(baseToken_, destToken_);
     }
 
     function convert(

--- a/contracts/mock/libs/decimals/DecimalsConverterMock.sol
+++ b/contracts/mock/libs/decimals/DecimalsConverterMock.sol
@@ -15,7 +15,7 @@ contract DecimalsConverterMock {
         return amount_.to18(baseDecimals_);
     }
 
-    function to18(uint256 amount_, address token_) external view returns (uint256) {
+    function tokenTo18(uint256 amount_, address token_) external view returns (uint256) {
         return amount_.to18(token_);
     }
 
@@ -23,7 +23,7 @@ contract DecimalsConverterMock {
         return amount_.to18Safe(baseDecimals_);
     }
 
-    function to18Safe(uint256 amount_, address token_) external view returns (uint256) {
+    function tokenTo18Safe(uint256 amount_, address token_) external view returns (uint256) {
         return amount_.to18Safe(token_);
     }
 
@@ -31,7 +31,7 @@ contract DecimalsConverterMock {
         return amount_.from18(destDecimals_);
     }
 
-    function from18(uint256 amount_, address token_) external view returns (uint256) {
+    function tokenFrom18(uint256 amount_, address token_) external view returns (uint256) {
         return amount_.from18(token_);
     }
 
@@ -39,7 +39,7 @@ contract DecimalsConverterMock {
         return amount_.from18Safe(destDecimals_);
     }
 
-    function from18Safe(uint256 amount_, address token_) external view returns (uint256) {
+    function tokenFrom18Safe(uint256 amount_, address token_) external view returns (uint256) {
         return amount_.from18Safe(token_);
     }
 
@@ -59,7 +59,7 @@ contract DecimalsConverterMock {
         return amount_.convert(baseDecimals_, destDecimals_);
     }
 
-    function convert(
+    function convertTokens(
         uint256 amount_,
         address baseToken_,
         address destToken_

--- a/contracts/mock/libs/decimals/DecimalsConverterMock.sol
+++ b/contracts/mock/libs/decimals/DecimalsConverterMock.sol
@@ -51,19 +51,27 @@ contract DecimalsConverterMock {
         return amount_.round18Safe(decimals_);
     }
 
-    function roundTokens(
+    function convert(
+        uint256 amount_,
+        uint256 baseDecimals_,
+        uint256 destDecimals_
+    ) external pure returns (uint256) {
+        return amount_.convert(baseDecimals_, destDecimals_);
+    }
+
+    function convert(
         uint256 amount_,
         address baseToken_,
         address destToken_
     ) public view returns (uint256) {
-        return amount_.roundTokens(baseToken_, destToken_);
+        return amount_.convert(baseToken_, destToken_);
     }
 
-    function roundTokensSave(
+    function convertTokensSafe(
         uint256 amount_,
         address baseToken_,
         address destToken_
     ) external view returns (uint256) {
-        return amount_.roundTokensSave(baseToken_, destToken_);
+        return amount_.convertTokensSafe(baseToken_, destToken_);
     }
 }

--- a/contracts/mock/libs/decimals/DecimalsConverterMock.sol
+++ b/contracts/mock/libs/decimals/DecimalsConverterMock.sol
@@ -15,16 +15,32 @@ contract DecimalsConverterMock {
         return amount_.to18(baseDecimals_);
     }
 
+    function to18(uint256 amount_, address token_) external view returns (uint256) {
+        return amount_.to18(token_);
+    }
+
     function to18Safe(uint256 amount_, uint256 baseDecimals_) external pure returns (uint256) {
         return amount_.to18Safe(baseDecimals_);
+    }
+
+    function to18Safe(uint256 amount_, address token_) external view returns (uint256) {
+        return amount_.to18Safe(token_);
     }
 
     function from18(uint256 amount_, uint256 destDecimals_) external pure returns (uint256) {
         return amount_.from18(destDecimals_);
     }
 
+    function from18(uint256 amount_, address token_) external view returns (uint256) {
+        return amount_.from18(token_);
+    }
+
     function from18Safe(uint256 amount_, uint256 destDecimals_) external pure returns (uint256) {
         return amount_.from18Safe(destDecimals_);
+    }
+
+    function from18Safe(uint256 amount_, address token_) external view returns (uint256) {
+        return amount_.from18Safe(token_);
     }
 
     function round18(uint256 amount_, uint256 decimals_) external pure returns (uint256) {
@@ -49,13 +65,5 @@ contract DecimalsConverterMock {
         address destToken_
     ) external view returns (uint256) {
         return amount_.roundTokensSave(baseToken_, destToken_);
-    }
-
-    function convert(
-        uint256 amount_,
-        uint256 baseDecimals_,
-        uint256 destDecimals_
-    ) external pure returns (uint256) {
-        return amount_.convert(baseDecimals_, destDecimals_);
     }
 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarity/solidity-lib",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "license": "MIT",
   "author": "Distributed Lab",
   "readme": "README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solarity/solidity-lib",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@solarity/solidity-lib",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solarity/solidity-lib",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "license": "MIT",
   "author": "Distributed Lab",
   "description": "Solidity Library by Distributed Lab",

--- a/test/libs/decimals/DecimalsConverter.test.js
+++ b/test/libs/decimals/DecimalsConverter.test.js
@@ -25,50 +25,97 @@ describe("DecimalsConverter", () => {
     });
   });
 
-  describe("convert", () => {
-    it("should convert", async () => {
-      assert.equal((await mock.convert(wei("1"), 18, 6)).toFixed(), wei("1", 6));
-      assert.equal((await mock.convert(wei("1", 6), 6, 18)).toFixed(), wei("1"));
-      assert.equal((await mock.convert(wei("1", 6), 18, 18)).toFixed(), wei("1", 6));
-    });
-  });
-
   describe("to18", () => {
     it("should convert to 18", async () => {
-      assert.equal((await mock.to18(wei("1", 6), 6)).toFixed(), wei("1"));
-      assert.equal((await mock.to18(wei("1", 8), 8)).toFixed(), wei("1"));
-      assert.equal((await mock.to18(wei("1", 6), 8)).toFixed(), wei("1", 16));
-      assert.equal((await mock.to18(wei("1", 30), 30)).toFixed(), wei("1"));
+      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 6), 6)).toFixed(), wei("1"));
+      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 8), 8)).toFixed(), wei("1"));
+      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 6), 8)).toFixed(), wei("1", 16));
+      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 30), 30)).toFixed(), wei("1"));
+    });
+
+    it("should convert from token decimals to 18", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 6);
+      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 6), token1.address)).toFixed(), wei("1"));
+
+      const token2 = await ERC20Mock.new("MK2", "MK2", 6);
+      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 8), token2.address)).toFixed(), wei("1", 20));
+
+      const token3 = await ERC20Mock.new("MK2", "MK2", 18);
+      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 6), token3.address)).toFixed(), wei("1", 6));
+
+      const token4 = await ERC20Mock.new("MK2", "MK2", 30);
+      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 30), token4.address)).toFixed(), wei("1"));
     });
   });
 
   describe("to18Safe", () => {
     it("should correctly convert to 18", async () => {
-      assert.equal((await mock.to18Safe(wei("1", 6), 6)).toFixed(), wei("1"));
-      assert.equal((await mock.to18Safe(wei("1", 8), 8)).toFixed(), wei("1"));
+      assert.equal((await mock.methods["to18Safe(uint256,uint256)"](wei("1", 6), 6)).toFixed(), wei("1"));
+      assert.equal((await mock.methods["to18Safe(uint256,uint256)"](wei("1", 8), 8)).toFixed(), wei("1"));
+    });
+
+    it("should correctly convert from token decimals to 18", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 6);
+      assert.equal((await mock.methods["to18Safe(uint256,address)"](wei("1", 6), token1.address)).toFixed(), wei("1"));
+
+      const token2 = await ERC20Mock.new("MK2", "MK2", 8);
+      assert.equal((await mock.methods["to18Safe(uint256,address)"](wei("1", 8), token2.address)).toFixed(), wei("1"));
     });
 
     it("should get exception if the result of conversion is zero", async () => {
       const reason = "DecimalsConverter: conversion failed";
 
-      await truffleAssert.reverts(mock.to18Safe(wei("1", 11), 30), reason);
+      await truffleAssert.reverts(mock.methods["to18Safe(uint256,uint256)"](wei("1", 11), 30), reason);
     });
   });
 
   describe("from18", () => {
     it("should convert from 18", async () => {
-      assert.equal((await mock.from18(wei("1"), 6)).toFixed(), wei("1", 6));
-      assert.equal((await mock.from18(wei("1"), 8)).toFixed(), wei("1", 8));
-      assert.equal((await mock.from18(wei("1", 16), 8)).toFixed(), wei("1", 6));
-      assert.equal((await mock.from18(wei("1", 5), 8)).toFixed(), "0");
-      assert.equal((await mock.from18(wei("1"), 30)).toFixed(), wei("1", 30));
+      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1"), 6)).toFixed(), wei("1", 6));
+      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1"), 8)).toFixed(), wei("1", 8));
+      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1", 16), 8)).toFixed(), wei("1", 6));
+      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1", 5), 8)).toFixed(), "0");
+      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1"), 30)).toFixed(), wei("1", 30));
+    });
+
+    it("should convert from 18 to token to token decimals", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 6);
+      assert.equal((await mock.methods["from18(uint256,address)"](wei("1"), token1.address)).toFixed(), wei("1", 6));
+
+      const token2 = await ERC20Mock.new("MK2", "MK2", 15);
+      assert.equal(
+        (await mock.methods["from18(uint256,address)"](wei("1", 12), token2.address)).toFixed(),
+        wei("1", 9)
+      );
+
+      const token3 = await ERC20Mock.new("MK2", "MK2", 18);
+      assert.equal((await mock.methods["from18(uint256,address)"](wei("1", 6), token3.address)).toFixed(), wei("1", 6));
+
+      const token4 = await ERC20Mock.new("MK2", "MK2", 25);
+      assert.equal(
+        (await mock.methods["from18(uint256,address)"](wei("1", 20), token4.address)).toFixed(),
+        wei("1", 27)
+      );
     });
   });
 
   describe("from18Safe", () => {
-    it("should correctly convert to 18", async () => {
+    it("should correctly convert from 18", async () => {
       assert.equal((await mock.from18Safe(wei("1"), 6)).toFixed(), wei("1", 6));
       assert.equal((await mock.from18Safe(wei("1"), 8)).toFixed(), wei("1", 8));
+    });
+    it("should correctly convert from 18 to token decimals", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 6);
+      assert.equal(
+        (await mock.methods["from18Safe(uint256,address)"](wei("1"), token1.address)).toFixed(),
+        wei("1", 6)
+      );
+
+      const token2 = await ERC20Mock.new("MK2", "MK2", 15);
+      assert.equal(
+        (await mock.methods["from18Safe(uint256,address)"](wei("1", 12), token2.address)).toFixed(),
+        wei("1", 9)
+      );
     });
 
     it("should get exception if the result of conversion is zero", async () => {

--- a/test/libs/decimals/DecimalsConverter.test.js
+++ b/test/libs/decimals/DecimalsConverter.test.js
@@ -100,4 +100,31 @@ describe("DecimalsConverter", () => {
       await truffleAssert.reverts(mock.round18Safe(wei("1", 6), 6), reason);
     });
   });
+
+  describe("roundTokens", () => {
+    it("should round tokens decimals", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 18);
+      const token2 = await ERC20Mock.new("MK2", "MK2", 3);
+
+      assert.equal((await mock.roundTokens(wei("1"), token1.address, token2.address)).toFixed(), wei("1", 3));
+      assert.equal((await mock.roundTokens(wei("1", 3), token2.address, token1.address)).toFixed(), wei("1"));
+    });
+  });
+  describe("roundTokensSafe", () => {
+    it("should round tokens decimals", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 6);
+      const token2 = await ERC20Mock.new("MK2", "MK2", 9);
+
+      assert.equal((await mock.roundTokensSave(wei("1", 6), token1.address, token2.address)).toFixed(), wei("1", 9));
+      assert.equal((await mock.roundTokensSave(wei("1", 9), token2.address, token1.address)).toFixed(), wei("1", 6));
+    });
+    it("should get exception if the result of conversion is zero", async () => {
+      const token1 = await ERC20Mock.new("MK1", "MK1", 18);
+      const token2 = await ERC20Mock.new("MK2", "MK2", 3);
+
+      const reason = "DecimalsConverter: conversion failed";
+
+      await truffleAssert.reverts(mock.roundTokensSave(wei("1", 3), token1.address, token2.address), reason);
+    });
+  });
 });

--- a/test/libs/decimals/DecimalsConverter.test.js
+++ b/test/libs/decimals/DecimalsConverter.test.js
@@ -27,26 +27,17 @@ describe("DecimalsConverter", () => {
 
   describe("convert", () => {
     it("should convert", async () => {
-      assert.equal((await mock.methods["convert(uint256,uint256,uint256)"](wei("1"), 18, 6)).toFixed(), wei("1", 6));
-      assert.equal((await mock.methods["convert(uint256,uint256,uint256)"](wei("1", 6), 6, 18)).toFixed(), wei("1"));
-      assert.equal(
-        (await mock.methods["convert(uint256,uint256,uint256)"](wei("1", 6), 18, 18)).toFixed(),
-        wei("1", 6)
-      );
+      assert.equal((await mock.convert(wei("1"), 18, 6)).toFixed(), wei("1", 6));
+      assert.equal((await mock.convert(wei("1", 6), 6, 18)).toFixed(), wei("1"));
+      assert.equal((await mock.convert(wei("1", 6), 18, 18)).toFixed(), wei("1", 6));
     });
 
     it("should convert tokens", async () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 18);
       const token2 = await ERC20Mock.new("MK2", "MK2", 3);
 
-      assert.equal(
-        (await mock.methods["convert(uint256,address,address)"](wei("1"), token1.address, token2.address)).toFixed(),
-        wei("1", 3)
-      );
-      assert.equal(
-        (await mock.methods["convert(uint256,address,address)"](wei("1", 3), token2.address, token1.address)).toFixed(),
-        wei("1")
-      );
+      assert.equal((await mock.convertTokens(wei("1"), token1.address, token2.address)).toFixed(), wei("1", 3));
+      assert.equal((await mock.convertTokens(wei("1", 3), token2.address, token1.address)).toFixed(), wei("1"));
     });
   });
 
@@ -55,103 +46,85 @@ describe("DecimalsConverter", () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 6);
       const token2 = await ERC20Mock.new("MK2", "MK2", 9);
 
-      assert.equal(
-        (
-          await mock.methods["convertTokensSafe(uint256,address,address)"](wei("1", 6), token1.address, token2.address)
-        ).toFixed(),
-        wei("1", 9)
-      );
-      assert.equal(
-        (
-          await mock.methods["convertTokensSafe(uint256,address,address)"](wei("1", 9), token2.address, token1.address)
-        ).toFixed(),
-        wei("1", 6)
-      );
+      assert.equal((await mock.convertTokensSafe(wei("1", 6), token1.address, token2.address)).toFixed(), wei("1", 9));
+      assert.equal((await mock.convertTokensSafe(wei("1", 9), token2.address, token1.address)).toFixed(), wei("1", 6));
     });
+
     it("should get exception if the result of conversion is zero", async () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 18);
       const token2 = await ERC20Mock.new("MK2", "MK2", 3);
 
       const reason = "DecimalsConverter: conversion failed";
 
-      await truffleAssert.reverts(
-        mock.methods["convertTokensSafe(uint256,address,address)"](wei("1", 3), token1.address, token2.address),
-        reason
-      );
+      await truffleAssert.reverts(mock.convertTokensSafe(wei("1", 3), token1.address, token2.address), reason);
     });
   });
 
   describe("to18", () => {
     it("should convert to 18", async () => {
-      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 6), 6)).toFixed(), wei("1"));
-      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 8), 8)).toFixed(), wei("1"));
-      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 6), 8)).toFixed(), wei("1", 16));
-      assert.equal((await mock.methods["to18(uint256,uint256)"](wei("1", 30), 30)).toFixed(), wei("1"));
+      assert.equal((await mock.to18(wei("1", 6), 6)).toFixed(), wei("1"));
+      assert.equal((await mock.to18(wei("1", 8), 8)).toFixed(), wei("1"));
+      assert.equal((await mock.to18(wei("1", 6), 8)).toFixed(), wei("1", 16));
+      assert.equal((await mock.to18(wei("1", 30), 30)).toFixed(), wei("1"));
     });
 
     it("should convert from token decimals to 18", async () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 6);
-      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 6), token1.address)).toFixed(), wei("1"));
+      assert.equal((await mock.tokenTo18(wei("1", 6), token1.address)).toFixed(), wei("1"));
 
       const token2 = await ERC20Mock.new("MK2", "MK2", 6);
-      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 8), token2.address)).toFixed(), wei("1", 20));
+      assert.equal((await mock.tokenTo18(wei("1", 8), token2.address)).toFixed(), wei("1", 20));
 
       const token3 = await ERC20Mock.new("MK2", "MK2", 18);
-      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 6), token3.address)).toFixed(), wei("1", 6));
+      assert.equal((await mock.tokenTo18(wei("1", 6), token3.address)).toFixed(), wei("1", 6));
 
       const token4 = await ERC20Mock.new("MK2", "MK2", 30);
-      assert.equal((await mock.methods["to18(uint256,address)"](wei("1", 30), token4.address)).toFixed(), wei("1"));
+      assert.equal((await mock.tokenTo18(wei("1", 30), token4.address)).toFixed(), wei("1"));
     });
   });
 
   describe("to18Safe", () => {
     it("should correctly convert to 18", async () => {
-      assert.equal((await mock.methods["to18Safe(uint256,uint256)"](wei("1", 6), 6)).toFixed(), wei("1"));
-      assert.equal((await mock.methods["to18Safe(uint256,uint256)"](wei("1", 8), 8)).toFixed(), wei("1"));
+      assert.equal((await mock.to18Safe(wei("1", 6), 6)).toFixed(), wei("1"));
+      assert.equal((await mock.to18Safe(wei("1", 8), 8)).toFixed(), wei("1"));
     });
 
     it("should correctly convert from token decimals to 18", async () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 6);
-      assert.equal((await mock.methods["to18Safe(uint256,address)"](wei("1", 6), token1.address)).toFixed(), wei("1"));
+      assert.equal((await mock.tokenTo18Safe(wei("1", 6), token1.address)).toFixed(), wei("1"));
 
       const token2 = await ERC20Mock.new("MK2", "MK2", 8);
-      assert.equal((await mock.methods["to18Safe(uint256,address)"](wei("1", 8), token2.address)).toFixed(), wei("1"));
+      assert.equal((await mock.tokenTo18Safe(wei("1", 8), token2.address)).toFixed(), wei("1"));
     });
 
     it("should get exception if the result of conversion is zero", async () => {
       const reason = "DecimalsConverter: conversion failed";
 
-      await truffleAssert.reverts(mock.methods["to18Safe(uint256,uint256)"](wei("1", 11), 30), reason);
+      await truffleAssert.reverts(mock.to18Safe(wei("1", 11), 30), reason);
     });
   });
 
   describe("from18", () => {
     it("should convert from 18", async () => {
-      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1"), 6)).toFixed(), wei("1", 6));
-      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1"), 8)).toFixed(), wei("1", 8));
-      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1", 16), 8)).toFixed(), wei("1", 6));
-      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1", 5), 8)).toFixed(), "0");
-      assert.equal((await mock.methods["from18(uint256,uint256)"](wei("1"), 30)).toFixed(), wei("1", 30));
+      assert.equal((await mock.from18(wei("1"), 6)).toFixed(), wei("1", 6));
+      assert.equal((await mock.from18(wei("1"), 8)).toFixed(), wei("1", 8));
+      assert.equal((await mock.from18(wei("1", 16), 8)).toFixed(), wei("1", 6));
+      assert.equal((await mock.from18(wei("1", 5), 8)).toFixed(), "0");
+      assert.equal((await mock.from18(wei("1"), 30)).toFixed(), wei("1", 30));
     });
 
     it("should convert from 18 to token to token decimals", async () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 6);
-      assert.equal((await mock.methods["from18(uint256,address)"](wei("1"), token1.address)).toFixed(), wei("1", 6));
+      assert.equal((await mock.tokenFrom18(wei("1"), token1.address)).toFixed(), wei("1", 6));
 
       const token2 = await ERC20Mock.new("MK2", "MK2", 15);
-      assert.equal(
-        (await mock.methods["from18(uint256,address)"](wei("1", 12), token2.address)).toFixed(),
-        wei("1", 9)
-      );
+      assert.equal((await mock.tokenFrom18(wei("1", 12), token2.address)).toFixed(), wei("1", 9));
 
       const token3 = await ERC20Mock.new("MK2", "MK2", 18);
-      assert.equal((await mock.methods["from18(uint256,address)"](wei("1", 6), token3.address)).toFixed(), wei("1", 6));
+      assert.equal((await mock.tokenFrom18(wei("1", 6), token3.address)).toFixed(), wei("1", 6));
 
       const token4 = await ERC20Mock.new("MK2", "MK2", 25);
-      assert.equal(
-        (await mock.methods["from18(uint256,address)"](wei("1", 20), token4.address)).toFixed(),
-        wei("1", 27)
-      );
+      assert.equal((await mock.tokenFrom18(wei("1", 20), token4.address)).toFixed(), wei("1", 27));
     });
   });
 
@@ -160,18 +133,13 @@ describe("DecimalsConverter", () => {
       assert.equal((await mock.from18Safe(wei("1"), 6)).toFixed(), wei("1", 6));
       assert.equal((await mock.from18Safe(wei("1"), 8)).toFixed(), wei("1", 8));
     });
+
     it("should correctly convert from 18 to token decimals", async () => {
       const token1 = await ERC20Mock.new("MK1", "MK1", 6);
-      assert.equal(
-        (await mock.methods["from18Safe(uint256,address)"](wei("1"), token1.address)).toFixed(),
-        wei("1", 6)
-      );
+      assert.equal((await mock.tokenFrom18Safe(wei("1"), token1.address)).toFixed(), wei("1", 6));
 
       const token2 = await ERC20Mock.new("MK2", "MK2", 15);
-      assert.equal(
-        (await mock.methods["from18Safe(uint256,address)"](wei("1", 12), token2.address)).toFixed(),
-        wei("1", 9)
-      );
+      assert.equal((await mock.tokenFrom18Safe(wei("1", 12), token2.address)).toFixed(), wei("1", 9));
     });
 
     it("should get exception if the result of conversion is zero", async () => {

--- a/test/libs/decimals/DecimalsConverter.test.js
+++ b/test/libs/decimals/DecimalsConverter.test.js
@@ -75,10 +75,10 @@ describe("DecimalsConverter", () => {
       const token2 = await ERC20Mock.new("MK2", "MK2", 6);
       assert.equal((await mock.tokenTo18(wei("1", 8), token2.address)).toFixed(), wei("1", 20));
 
-      const token3 = await ERC20Mock.new("MK2", "MK2", 18);
+      const token3 = await ERC20Mock.new("MK3", "MK3", 18);
       assert.equal((await mock.tokenTo18(wei("1", 6), token3.address)).toFixed(), wei("1", 6));
 
-      const token4 = await ERC20Mock.new("MK2", "MK2", 30);
+      const token4 = await ERC20Mock.new("MK4", "MK4", 30);
       assert.equal((await mock.tokenTo18(wei("1", 30), token4.address)).toFixed(), wei("1"));
     });
   });
@@ -120,10 +120,10 @@ describe("DecimalsConverter", () => {
       const token2 = await ERC20Mock.new("MK2", "MK2", 15);
       assert.equal((await mock.tokenFrom18(wei("1", 12), token2.address)).toFixed(), wei("1", 9));
 
-      const token3 = await ERC20Mock.new("MK2", "MK2", 18);
+      const token3 = await ERC20Mock.new("MK3", "MK3", 18);
       assert.equal((await mock.tokenFrom18(wei("1", 6), token3.address)).toFixed(), wei("1", 6));
 
-      const token4 = await ERC20Mock.new("MK2", "MK2", 25);
+      const token4 = await ERC20Mock.new("MK4", "MK4", 25);
       assert.equal((await mock.tokenFrom18(wei("1", 20), token4.address)).toFixed(), wei("1", 27));
     });
   });


### PR DESCRIPTION
<!-- 
Thank you for contributing to Solarity! 

Please consider ticking the relevant statements.
-->

- [ ] Since this PR suggests a **bug fix**, the tests have been added and the coverage is 100%.
- [x] Since this PR introduces a **new feature**, the update has been discussed in an Issue or with the team.
- [ ] This PR is just a **minor change**, like a typo fix.

---


<!-- Add the PR description here. -->

Added token decimals converter. The function accepts:

1. The amount of the base token.
2. The base token address.
3. The destination token address.

Under the hood, the function casts the addresses of the tokens to the IERC20Metadata interface and retrieves the decimals for both tokens. Then, it converts the amount with the decimals of the base token to the decimals of the destination token.

All necessary tests are added. Coverage 100%.

