### PR TITLE
Grammar & Clarity Fixes

### DIFF
--- a/contracts/access/PermanentOwnable.sol
+++ b/contracts/access/PermanentOwnable.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.4;
  * The owner is set to the address provided by the deployer. The ownership cannot be further changed.
  *
  * This module will make available the modifier `onlyOwner`, which can be applied
- * to your functions to restrict their use to the owners.
+ * to your functions to restrict their use to the owner.
  */
 abstract contract PermanentOwnable {
     address private immutable _OWNER;
@@ -28,7 +28,7 @@ abstract contract PermanentOwnable {
      * @param owner_ the address of the permanent owner.
      */
     constructor(address owner_) {
-        require(owner_ != address(0), "PermanentOwnable: zero address can not be the owner");
+        require(owner_ != address(0), "PermanentOwnable: zero address cannot be the owner");
 
         _OWNER = owner_;
     }

--- a/contracts/contracts-registry/pools/AbstractPoolContractsRegistry.sol
+++ b/contracts/contracts-registry/pools/AbstractPoolContractsRegistry.sol
@@ -53,7 +53,7 @@ abstract contract AbstractPoolContractsRegistry is Initializable, AbstractDepend
     /**
      * @notice The function to add new pools into the registry. Gets called from PoolFactory
      *
-     * Proper only factory access control must be added in descending contracts + `_addProxyPool()` should be called inside.
+     * Proper only factory access control must be added in descendant contracts + `_addProxyPool()` should be called inside.
      *
      * @param name_ the pool's associated name
      * @param poolAddress_ the proxy address of the pool
@@ -91,7 +91,7 @@ abstract contract AbstractPoolContractsRegistry is Initializable, AbstractDepend
      * @notice The function to check if the address is a pool
      * @param name_ the associated pools name
      * @param pool_ the address to check
-     * @return true if pool_ is whithing the registry
+     * @return true if pool_ is within the registry
      */
     function isPool(string memory name_, address pool_) public view returns (bool) {
         return _pools[name_].contains(pool_);


### PR DESCRIPTION
In PermanentOwnable.sol, changed "to the owners" to "to the owner" for singular clarity.
In PermanentOwnable.sol, changed "can not" to "cannot" for correct grammar.
In AbstractPoolContractsRegistry.sol, changed "descending contracts" to "descendant contracts" to use the correct terminology.
In AbstractPoolContractsRegistry.sol, fixed the typo "whithing" to "within" for proper spelling.