### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/changelog-validate.yml
+++ b/.github/workflows/changelog-validate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Checkout Docs Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: dl-solarity/docs
           ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/setup
@@ -41,7 +41,7 @@ jobs:
     if: needs.state.outputs.is_release_commit == 'true'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -61,7 +61,7 @@ jobs:
     if: needs.state.outputs.is_release_commit == 'true'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run tests


### PR DESCRIPTION
- [x] Since this PR suggests a **bug fix**, the tests have been added and the coverage is 100%.
- [ ] Since this PR introduces a **new feature**, the update has been discussed in an Issue or with the team.
- [ ] This PR is just a **minor change**, like a typo fix.

Bumps checkout to v5 for future-proofing against Node 24 runner updates.
Requires runner v2.327.1+. Workflows compile the same.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0
