### PR TITLE
Re-enabling tests for ECDSA libs

### DIFF
--- a/test/libs/crypto/ECDSA384.test.ts
+++ b/test/libs/crypto/ECDSA384.test.ts
@@ -30,7 +30,7 @@ function modifyRight(value: string, modifier: string): string {
   return newSignature;
 }
 
-describe.skip("ECDSA384", () => {
+describe("ECDSA384", () => {
   const reverter = new Reverter();
 
   let ecdsa384: ECDSA384Mock;

--- a/test/libs/crypto/ECDSA512.test.ts
+++ b/test/libs/crypto/ECDSA512.test.ts
@@ -4,7 +4,7 @@ import { Reverter } from "@/test/helpers/reverter";
 
 import { ECDSA512Mock } from "@ethers-v6";
 
-describe.skip("ECDSA512", () => {
+describe("ECDSA512", () => {
   const reverter = new Reverter();
 
   let ecdsa512: ECDSA512Mock;


### PR DESCRIPTION
<!-- 
Thank you for contributing to Solarity! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and consider ticking the relevant statements below.
-->

Hello — I don't know the reason these tests were skipped, but as they're passing, I decided to re-enable without changing anything. Does anyone have the context here?

Thank you for the great work on the project.

- [x] Since this PR suggests a **bug fix**, the tests have been added and the coverage is 100%.
- [ ] Since this PR introduces a **new feature**, the update has been discussed in an Issue or with the team.
- [ ] This PR is just a **minor change**, like a typo fix.

---

<!-- Add the PR description here. -->
